### PR TITLE
Feature/107-110/endpoints for comments

### DIFF
--- a/src/server/api/controllers/comments.controller.js
+++ b/src/server/api/controllers/comments.controller.js
@@ -9,10 +9,10 @@ const createComment = async ({
   fk_user_id,
 }) => {
   await knex('comments').insert({
-    description: description,
-    fk_annotations_id: fk_annotations_id,
-    fk_comments_id: fk_comments_id,
-    fk_user_id: fk_user_id,
+    description,
+    fk_annotations_id,
+    fk_comments_id,
+    fk_user_id,
   });
 
   return {
@@ -22,13 +22,13 @@ const createComment = async ({
 
 const getCommentsForAnnotation = (fk_annotations_id) => {
   return knex('comments')
-    .where({ fk_annotations_id: fk_annotations_id })
+    .where({ fk_annotations_id })
     .select('*');
 };
 
 const updateCommentById = (comment_id, body) => {
   return knex('comments')
-    .where({ comment_id: comment_id })
+    .where({ comment_id })
     .update({
       description: body.description,
       updated_at: new Date(),
@@ -37,7 +37,7 @@ const updateCommentById = (comment_id, body) => {
 
 const deleteCommentById = (comment_id) => {
   return knex('comments')
-    .where({ comment_id: comment_id })
+    .where({ comment_id })
     .del();
 };
 

--- a/src/server/api/controllers/comments.controller.js
+++ b/src/server/api/controllers/comments.controller.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const knex = require('../../config/db');
+
+const getCommentsForAnnotation = (fk_annotations_id) => {
+  return knex('comments')
+    .where({ fk_annotations_id: fk_annotations_id })
+    .select('*');
+};
+
+const updateComment = (comment_id, body) => {
+  return knex('comments')
+    .where({ comment_id: comment_id })
+    .update({
+      description: body.description,
+      updated_at: new Date(),
+    });
+};
+
+module.exports = {
+  getCommentsForAnnotation,
+  updateComment,
+};

--- a/src/server/api/controllers/comments.controller.js
+++ b/src/server/api/controllers/comments.controller.js
@@ -2,13 +2,31 @@
 
 const knex = require('../../config/db');
 
+const createComment = async ({
+  description,
+  fk_annotations_id,
+  fk_comments_id,
+  fk_user_id,
+}) => {
+  await knex('comments').insert({
+    description: description,
+    fk_annotations_id: fk_annotations_id,
+    fk_comments_id: fk_comments_id,
+    fk_user_id: fk_user_id,
+  });
+
+  return {
+    successful: true,
+  };
+};
+
 const getCommentsForAnnotation = (fk_annotations_id) => {
   return knex('comments')
     .where({ fk_annotations_id: fk_annotations_id })
     .select('*');
 };
 
-const updateComment = (comment_id, body) => {
+const updateCommentById = (comment_id, body) => {
   return knex('comments')
     .where({ comment_id: comment_id })
     .update({
@@ -17,7 +35,15 @@ const updateComment = (comment_id, body) => {
     });
 };
 
+const deleteCommentById = (comment_id) => {
+  return knex('comments')
+    .where({ comment_id: comment_id })
+    .del();
+};
+
 module.exports = {
+  createComment,
   getCommentsForAnnotation,
-  updateComment,
+  updateCommentById,
+  deleteCommentById,
 };

--- a/src/server/api/routes/api-router.js
+++ b/src/server/api/routes/api-router.js
@@ -3,10 +3,11 @@ const express = require('express');
 const router = express.Router();
 
 // Router imports
-const modulesRouter = require('./modules.router');
+// const modulesRouter = require('./modules.router');
 const userRouter = require('./users.router');
 const screenshotsRouter = require('./screenshots.router');
 const annotationsRouter = require('./annotations.router');
+const commentsRouter = require('./comments.router');
 
 // swagger-ui-express
 const swaggerDocument = require('../../config/swagger.json');
@@ -16,9 +17,11 @@ const swaggerUi = require('swagger-ui-express');
 router.use('/documentation', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Application routes
-router.use('/modules', modulesRouter);
+// router.use('/modules', modulesRouter);
 router.use('/users', userRouter);
 router.use('/screenshots', screenshotsRouter);
 router.use('/annotations', annotationsRouter);
+router.use('/comments', commentsRouter);
+
 
 module.exports = router;

--- a/src/server/api/routes/comments.router.js
+++ b/src/server/api/routes/comments.router.js
@@ -7,6 +7,21 @@ const router = express.Router({ mergeParams: true });
 // controllers
 const commentsController = require('../controllers/comments.controller');
 
+// ENDPOINT: /api/comments/ :POST to create new comment for an annotation
+router.post('/', (req, res) => {
+  commentsController
+    .createComment(req.body)
+    .then((result) => {
+      res.json(result);
+    })
+    .catch(() => {
+      res
+        .status(400)
+        .send('Bad request')
+        .end();
+    });
+});
+
 // ENDPOINT: /api/comments/annotation/:fk_annotation_id :GET to get all comments added to a specific annotation
 router.get('/annotation/:fk_annotations_id', (req, res, next) => {
   commentsController
@@ -15,10 +30,18 @@ router.get('/annotation/:fk_annotations_id', (req, res, next) => {
     .catch(next);
 });
 
-// ENDPOINT: /api/comments/:comment_id :PUT update comment for an annotation
+// ENDPOINT: /api/comments/:comment_id :PUT to update comment for an annotation
 router.put('/:comment_id', (req, res, next) => {
   commentsController
-    .updateComment(req.params.comment_id, req.body)
+    .updateCommentById(req.params.comment_id, req.body)
+    .then((result) => res.json({ success: result === 1 }))
+    .catch(next);
+});
+
+// ENDPOINT: /api/comments/:comment_id :DELETE to delete comment for an annotation
+router.delete('/:comment_id', (req, res, next) => {
+  commentsController
+    .deleteCommentById(req.params.comment_id)
     .then((result) => res.json({ success: result === 1 }))
     .catch(next);
 });

--- a/src/server/api/routes/comments.router.js
+++ b/src/server/api/routes/comments.router.js
@@ -15,7 +15,7 @@ router.get('/annotation/:fk_annotations_id', (req, res, next) => {
     .catch(next);
 });
 
-// ENDPOINT: /api/comments/ :PUT update comment for an annotation
+// ENDPOINT: /api/comments/:comment_id :PUT update comment for an annotation
 router.put('/:comment_id', (req, res, next) => {
   commentsController
     .updateComment(req.params.comment_id, req.body)

--- a/src/server/api/routes/comments.router.js
+++ b/src/server/api/routes/comments.router.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// router setup
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+
+// controllers
+const commentsController = require('../controllers/comments.controller');
+
+// ENDPOINT: /api/comments/annotation/:fk_annotation_id :GET to get all comments added to a specific annotation
+router.get('/annotation/:fk_annotations_id', (req, res, next) => {
+  commentsController
+    .getCommentsForAnnotation(req.params.fk_annotations_id)
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+// ENDPOINT: /api/comments/ :PUT update comment for an annotation
+router.put('/:comment_id', (req, res, next) => {
+  commentsController
+    .updateComment(req.params.comment_id, req.body)
+    .then((result) => res.json({ success: result === 1 }))
+    .catch(next);
+});
+
+module.exports = router;

--- a/src/server/api/routes/router.js
+++ b/src/server/api/routes/router.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 const router = express.Router();
 
-const modulesRouter = require('./modules.router');
+// const modulesRouter = require('./modules.router');
 const annotationsRouter = require('./annotations.router');
 
 router.use('/modules', modulesRouter);

--- a/src/server/config/swagger.json
+++ b/src/server/config/swagger.json
@@ -12,9 +12,9 @@
   "paths": {
     "/screenshots/{key}": {
       "get": {
-        "tags": ["Screenshot"],
-        "summary": "Checks the status of a taken screenshot and returns information about the screenshot if it's ready.",
-        "operationId": "Screenshot_CheckStatusOnScreenshot",
+        "tags": ["Screenshots"],
+        "summary": "Get a screenshot using a unique key.",
+        "operationId": "GetScreenshot",
         "consumes": [],
         "produces": [
           "application/json",
@@ -41,9 +41,9 @@
         }
       }
     },
-
     "/screenshots/": {
       "post": {
+        "tags": ["Screenshots"],
         "summary": "Create new screenshot",
         "consumes": ["application/json"],
         "parameters": [
@@ -81,43 +81,100 @@
           }
         }
       }
-    }
-  },
-  "/annotations/": {
-    "post": {
-      "tags": ["Annotations"],
-      "summary": "Create new annotation",
-      "consumes": ["application/json"],
-      "parameters": [
-        {
-          "name": "body",
-          "in": "body",
-          "description": "Create annotation",
-          "required": true,
-          "schema": {
-            "type": "object",
-            "required": ["title", "description", "area", "fk_screenshot_id"],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              },
-              "area": {
-                "type": "object",
-                "format": "object"
-              },
-              "fk_screenshot_id": {
-                "type": "integer"
+    },
+    "/annotations/": {
+      "post": {
+        "tags": ["Annotations"],
+        "summary": "Create new annotation",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Create annotation",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": ["title", "description", "area", "fk_screenshot_id"],
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "area": {
+                  "type": "object",
+                  "format": "object"
+                },
+                "fk_screenshot_id": {
+                  "type": "integer"
+                }
               }
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
         }
-      ],
-      "responses": {
-        "200": {
-          "description": "successful operation"
+      }
+    },
+    "/comments/{comment_id}": {
+      "put": {
+        "tags": ["Comments"],
+        "summary": "Update a comment",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "description": "The unique comment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Update comment for an annotation",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": ["description"],
+              "properties": {
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/comments/annotation/{annotation_id}": {
+      "get": {
+        "tags": ["Comments"],
+        "summary": "Get all comments for a specific annotation",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "annotation_id",
+            "in": "path",
+            "description": "The unique annotation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
         }
       }
     }

--- a/src/server/config/swagger.json
+++ b/src/server/config/swagger.json
@@ -121,6 +121,44 @@
         }
       }
     },
+    "/comments/": {
+      "post": {
+        "tags": ["Comments"],
+        "summary": "Create new comment for an annotation",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Create comment",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": ["description", "fk_annotations_id", "fk_comments_id", "fk_user_id"],
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "fk_annotations_id": {
+                  "type": "integer"
+                },
+                "fk_comments_id": {
+                  "type": "integer"
+                },
+                "fk_user_id": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
     "/comments/{comment_id}": {
       "put": {
         "tags": ["Comments"],
@@ -148,6 +186,25 @@
                 }
               }
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Comments"],
+        "summary": "Delete a comment",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "description": "The unique comment_id",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {

--- a/src/server/config/swagger.json
+++ b/src/server/config/swagger.json
@@ -10,33 +10,77 @@
   "basePath": "/api",
   "schemes": ["http", "https"],
   "paths": {
-    "/screenshots/{key}": {
-      "get": {
-        "tags": ["Screenshots"],
-        "summary": "Get a screenshot using a unique key.",
-        "operationId": "GetScreenshot",
-        "consumes": [],
-        "produces": [
-          "application/json",
-          "text/json",
-          "application/xml",
-          "text/xml"
-        ],
+    "/users/": {
+      "post": {
+        "tags": ["Users"],
+        "summary": "Create a new user",
+        "consumes": ["application/json"],
         "parameters": [
           {
-            "name": "key",
+            "name": "body",
+            "in": "body",
+            "description": "Create new user",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": ["name", "fk_role_id"],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "fk_role_id": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/users/{user_id}": {
+      "get": {
+        "tags": ["Users"],
+        "summary": "Get a user by user_id",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "user_id",
             "in": "path",
-            "description": "The unique key for the screenshot",
+            "description": "The unique user_id",
+            "required": true,
+            "type": "string",
+            "properties": {
+              "name": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Users"],
+        "summary": "Delete a specific user",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "The unique user_id",
             "required": true,
             "type": "string"
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "schema": {
-              "type": "object"
-            }
+            "description": "successful operation"
           }
         }
       }
@@ -75,6 +119,37 @@
         "responses": {
           "200": {
             "description": "{\"key\":\"[unique key]\"}",
+            "schema": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "/screenshots/{key}": {
+      "get": {
+        "tags": ["Screenshots"],
+        "summary": "Get a screenshot using a unique key.",
+        "operationId": "GetScreenshot",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "The unique key for the screenshot",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
             "schema": {
               "type": "object"
             }
@@ -121,6 +196,38 @@
         }
       }
     },
+    "/projects/": {
+      "post": {
+        "tags": ["Projects"],
+        "summary": "Create new project",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Create new project",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": ["name", "fk_user_id"],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "fk_user_id": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
     "/projects/{project_id}": {
       "get": {
         "tags": ["Projects"],
@@ -145,22 +252,6 @@
             "description": "successful operation"
           }
         }
-      }
-    },
-    "/users/{user_id}": {
-      "get": {
-        "tags": ["Users"],
-        "summary": "Get a user by user_id",
-        "consumes": ["application/json"],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "description": "The unique user_id",
-            "required": true,
-            "type": "string",
-            "properties": {
-              "name": "string"
       },
       "put": {
         "tags": ["Projects"],
@@ -197,48 +288,6 @@
         }
       },
       "delete": {
-        "tags": ["Users"],
-        "summary": "Delete a specific user",
-        "consumes": ["application/json"],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "description": "The unique user_id",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
-    "/users/": {
-      "post": {
-        "tags": ["Users"],
-        "summary": "Create a new user",
-        "consumes": ["application/json"],
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "description": "Create new user",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "required": ["name", "fk_role_id"],
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "fk_role_id": {
-                  "type": "number"
-        }
-      },
-      "delete": {
         "tags": ["Projects"],
         "summary": "Delete a specific project",
         "consumes": ["application/json"],
@@ -255,29 +304,6 @@
           "200": {
             "description": "successful operation"
           }
-        }
-      }
-    },
-    "/projects/": {
-      "post": {
-        "tags": ["Projects"],
-        "summary": "Create new project",
-        "consumes": ["application/json"],
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "description": "Create new project",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "required": ["name", "fk_user_id"],
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "fk_user_id": {
-                  "type": "number"
         }
       }
     },
@@ -311,8 +337,16 @@
                 }
               }
             }
-          },
-          "/comments/": {
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/comments/": {
       "post": {
         "tags": ["Comments"],
         "summary": "Create new comment for an annotation",
@@ -325,7 +359,12 @@
             "required": true,
             "schema": {
               "type": "object",
-              "required": ["description", "fk_annotations_id", "fk_comments_id", "fk_user_id"],
+              "required": [
+                "description",
+                "fk_annotations_id",
+                "fk_comments_id",
+                "fk_user_id"
+              ],
               "properties": {
                 "description": {
                   "type": "string"
@@ -339,6 +378,9 @@
                 "fk_user_id": {
                   "type": "integer"
                 }
+              }
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -347,7 +389,7 @@
         }
       }
     },
-          "/comments/{comment_id}": {
+    "/comments/{comment_id}": {
       "put": {
         "tags": ["Comments"],
         "summary": "Update a comment",
@@ -391,10 +433,16 @@
             "name": "comment_id",
             "in": "path",
             "description": "The unique comment_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
         }
       }
     },
-          "/comments/annotation/{annotation_id}": {
+    "/comments/annotation/{annotation_id}": {
       "get": {
         "tags": ["Comments"],
         "summary": "Get all comments for a specific annotation",
@@ -406,7 +454,15 @@
             "description": "The unique annotation_id",
             "required": true,
             "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    }
   },
-  
   "definitions": {}
 }

--- a/src/server/migrations/20191227195759_comments.js
+++ b/src/server/migrations/20191227195759_comments.js
@@ -1,0 +1,44 @@
+exports.up = function(knex) {
+    return knex.schema.createTable('comments', (table) => {
+      table.increments('comment_id').notNullable();
+      table.string('description').notNullable();
+      table
+        .integer('fk_annotations_id')
+        .unsigned()
+        .notNullable()
+        .references('annotation_id')
+        .inTable('annotations')
+        .onDelete('CASCADE')
+        .index();
+      table
+        .integer('fk_comments_id')
+        .unsigned()
+        .nullable()
+        .references('comment_id')
+        .inTable('comments')
+        .onDelete('CASCADE')
+        .index();
+      table
+        .integer('fk_user_id')
+        .unsigned()
+        .nullable()
+        .references('user_id')
+        .inTable('users')
+        .onDelete('CASCADE')
+        .index();
+      table
+        .timestamp('created_at')
+        .defaultTo(knex.fn.now())
+        .notNullable();
+      table
+        .timestamp('updated_at')
+        .defaultTo(knex.fn.now())
+        .notNullable();
+      table.timestamp('deleted_at').nullable();
+    });
+  };
+  
+  exports.down = function(knex) {
+    return knex.schema.dropTable('comments');
+  };
+  

--- a/src/server/seeds/005_00_annotations.js
+++ b/src/server/seeds/005_00_annotations.js
@@ -1,0 +1,20 @@
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex('annotations')
+    .del()
+    .then(function() {
+      // Inserts seed entries
+      return knex('annotations').insert([
+        {
+          annotation_id: 1,
+          title: 'some',
+          description: 'something new',
+          area: `{
+            "width": 20,
+            "height": 20
+          }`,
+          fk_screenshot_id: 1,
+        },
+      ]);
+    });
+};

--- a/src/server/seeds/006_00_comments.js
+++ b/src/server/seeds/006_00_comments.js
@@ -1,0 +1,31 @@
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex('comments')
+    .del()
+    .then(function() {
+      // Inserts seed entries
+      return knex('comments').insert([
+        {
+          comment_id: 1,
+          description: 'comment1',
+          fk_annotations_id: 1,
+          fk_comments_id: null,
+          fk_user_id: 1,
+        },
+        {
+          comment_id: 2,
+          description: 'comment2',
+          fk_annotations_id: 1,
+          fk_comments_id: null,
+          fk_user_id: 1,
+        },
+        {
+          comment_id: 3,
+          description: 'comment3',
+          fk_annotations_id: 1,
+          fk_comments_id: 1,
+          fk_user_id: 1,
+        },
+      ]);
+    });
+};


### PR DESCRIPTION
- Created migration for comments table.

- Created seeds for annotations and comments table.

- Issue #107 Created endpoint for creating comment.

- Issue#108 Created endpoint for listing comments for a specific annotation. 
Path for reading comments for a specific annotation looks like this:
comments/annotation/:annotation_id

- Issue#109 Created endpoint for updating a comment.

- Issue#110 Created endpoint for deleting a comment.

- Created endpoints for a swagger.

I had to comment lines with modules router(in router.js, api-router.js), because we don't have it right now.
