### PR TITLE
#144 Footer fix

### DIFF
--- a/src/client/components/Footer/Footer.css
+++ b/src/client/components/Footer/Footer.css
@@ -10,7 +10,7 @@
 }
 .footer-links-wrapper {
   display: flex;
-  padding-left: 25%;
+  justify-content: center;
 }
 
 .footer-text {


### PR DESCRIPTION
Instead of having a padding: 25%, I used justify-content: center. So the footer links are always in the center. 