### PR TITLE
#146 Fixed content-text

### DIFF
--- a/src/client/components/content/Content.css
+++ b/src/client/components/content/Content.css
@@ -4,9 +4,7 @@
 .content-text {
   text-align: center;
   font-family: "Open Sans", sans-serif;
-  display: inline-block;
-  margin: 1em 1em 0 0;
-  padding: 0.1% 13%;
+  display: block;
 }
 .content-footer {
   display: flex;


### PR DESCRIPTION
- Removed paddings, margins
- instead of display: inline-block, used block

=> Text now should always be centered. 