### PR TITLE
Feature/230/connect annotation with list

### DIFF
--- a/src/client/App.css
+++ b/src/client/App.css
@@ -5,4 +5,5 @@
 
 body {
   margin: 0;
+  overflow-wrap: break-word;
 }

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -9,35 +9,38 @@ import ScreenshotsPage from './pages/Screenshots/ScreenshotsPage';
 import UserPage from './pages/User/UserPage';
 import ErrorPage from './pages/ErrorPage/ErrorPage';
 import { Provider } from './context/AuthContext';
+import { AnnotationProvider } from './context/AnnotationContext';
 
 function App() {
   return (
     <Provider>
-      <Router>
-        <Switch>
-          <Route exact path="/">
-            <Home />
-          </Route>
-          <Route exact path="/register">
-            <RegisterPage />
-          </Route>
-          <Route exact path="/login">
-            <LoginPage />
-          </Route>
-          <Route path="/projects">
-            <ProjectsPage />
-          </Route>
-          <Route exact path="/screenshots">
-            <ScreenshotsPage />
-          </Route>
-          <Route exact path="/user">
-            <UserPage />
-          </Route>
-          <Route exact path="*">
-            <ErrorPage />
-          </Route>
-        </Switch>
-      </Router>
+      <AnnotationProvider >
+        <Router>
+          <Switch>
+            <Route exact path="/">
+              <Home />
+            </Route>
+            <Route exact path="/register">
+              <RegisterPage />
+            </Route>
+            <Route exact path="/login">
+              <LoginPage />
+            </Route>
+            <Route path="/projects">
+              <ProjectsPage />
+            </Route>
+            <Route exact path="/screenshots">
+              <ScreenshotsPage />
+            </Route>
+            <Route exact path="/user">
+              <UserPage />
+            </Route>
+            <Route exact path="*">
+              <ErrorPage />
+            </Route>
+          </Switch>
+        </Router>
+      </AnnotationProvider>
     </Provider>
   );
 }

--- a/src/client/components/Annotation/CustomAnnotation.component.js
+++ b/src/client/components/Annotation/CustomAnnotation.component.js
@@ -1,32 +1,36 @@
 import React, { Component } from 'react';
 import Annotation from 'react-image-annotation';
 import EditorWrapper from './EditorWrapper';
+import {
+  AnnotationContext,
+  AnnotationConsumer,
+} from '../../context/AnnotationContext';
 
 class CustomAnnotation extends Component {
   constructor(props) {
-    super(props);   
+    super(props);
 
     this.state = {
       annotations: [],
       annotation: {},
       data: {},
-    };    
+    };
   }
 
   componentDidMount() {
-    const annotations = this.props.annotations.map(item => {
+    const annotations = this.props.annotations.map((item) => {
       const annotation = {};
       annotation.data = {
         id: item.annotation_id,
         description: item.description,
-        title: item.title
+        title: item.title,
       };
       annotation.geometry = item.area;
       return annotation;
-    })
-    this.setState({ annotations })
+    });
+    this.setState({ annotations });
   }
-  
+
   // state = {
   //   annotations: [],
   //   annotation: {},
@@ -81,47 +85,60 @@ class CustomAnnotation extends Component {
 
   render() {
     return (
-      <div className="App">
-        <Annotation
-          src={this.props.screenshot.src}
-          alt={this.props.screenshot.alt}
-          annotations={this.state.annotations}
-          type={this.state.type}
-          value={this.state.annotation}
-          onChange={this.onChange}
-          renderContent={({ annotation }) => {
-            const { geometry } = annotation;
-            return (
-              <div
-                key={annotation.data.id}
-                style={{
-                  background: 'black',
-                  color: 'white',
-                  padding: 10,
-                  position: 'absolute',
-                  fontSize: 12,
-                  left: `${geometry.x}%`,
-                  top: `${geometry.y + geometry.height}%`,
-                }}
-              >
-                <div>{annotation.data.title}</div>
-                {annotation.data && annotation.data.text}
-              </div>
-            );
-          }}
-          renderEditor={() => (
-            <EditorWrapper
-              onChange={this.onChange}
-              annotation={this.state.annotation}
-              description={this.description}
-              title={this.title}
-              onSubmit={this.onSubmit}
-            />
-          )}
-        />
-      </div>
+      <AnnotationConsumer>
+        {(context) => {
+          const highlightedAnnotation = context.state.annotationId ? this.state.annotations.find(ann => ann.data.id === context.state.annotationId) : null;
+          // console.log('highlightedAnnotation', highlightedAnnotation)
+          // console.log('context var from annotation', context.state.annotationId)
+          return (
+            <div className="App">
+              <Annotation className="x"
+                src={this.props.screenshot.src}
+                alt={this.props.screenshot.alt}
+                annotations={this.state.annotations}
+                type={this.state.type}
+                value={this.state.annotation}
+                onChange={this.onChange}
+                activeAnnotations={context.state.annotationId ? [highlightedAnnotation] : []}
+                activeAnnotationComparator={(current, active) => active.data.id === current.data.id}
+                renderContent={({ annotation }) => {
+                  const { geometry } = annotation;
+                  return (
+                    <div className="y"
+                      key={annotation.data.id}
+                      style={{
+                        background: 'black',
+                        color: 'white',
+                        padding: 10,
+                        position: 'absolute',
+                        fontSize: 12,
+                        left: `${geometry.x}%`,
+                        top: `${geometry.y + geometry.height}%`,
+                      }}
+                    >
+                      <div className="z">{annotation.data.title}</div>
+                      {annotation.data && annotation.data.text}
+                    </div>
+                  );
+                }}                
+                renderEditor={() => (
+                  <EditorWrapper
+                    onChange={this.onChange}
+                    annotation={this.state.annotation}
+                    description={this.description}
+                    title={this.title}
+                    onSubmit={this.onSubmit}
+                  />
+                )}
+              />
+            </div>
+          );
+        }}
+      </AnnotationConsumer>
     );
   }
 }
+
+CustomAnnotation.contextType = AnnotationContext;
 
 export default CustomAnnotation;

--- a/src/client/components/Annotation/CustomAnnotation.component.js
+++ b/src/client/components/Annotation/CustomAnnotation.component.js
@@ -3,11 +3,35 @@ import Annotation from 'react-image-annotation';
 import EditorWrapper from './EditorWrapper';
 
 class CustomAnnotation extends Component {
-  state = {
-    annotations: [],
-    annotation: {},
-    data: {},
-  };
+  constructor(props) {
+    super(props);   
+
+    this.state = {
+      annotations: [],
+      annotation: {},
+      data: {},
+    };    
+  }
+
+  componentDidMount() {
+    const annotations = this.props.annotations.map(item => {
+      const annotation = {};
+      annotation.data = {
+        id: item.annotation_id,
+        description: item.description,
+        title: item.title
+      };
+      annotation.geometry = item.area;
+      return annotation;
+    })
+    this.setState({ annotations })
+  }
+  
+  // state = {
+  //   annotations: [],
+  //   annotation: {},
+  //   data: {},
+  // };
 
   onChange = (annotation, value = {}) => {
     this.setState({
@@ -21,7 +45,8 @@ class CustomAnnotation extends Component {
   };
 
   onSubmit = (isClancelClicked) => {
-    let { annotation, annotations, data } = this.state;
+    const { annotation, annotations } = this.state;
+    let { data } = this.state;
     if (isClancelClicked === 'clicked') {
       data = {};
     }

--- a/src/client/components/Annotation/CustomAnnotation.component.js
+++ b/src/client/components/Annotation/CustomAnnotation.component.js
@@ -88,8 +88,6 @@ class CustomAnnotation extends Component {
       <AnnotationConsumer>
         {(context) => {
           const highlightedAnnotation = context.state.annotationId ? this.state.annotations.find(ann => ann.data.id === context.state.annotationId) : null;
-          // console.log('highlightedAnnotation', highlightedAnnotation)
-          // console.log('context var from annotation', context.state.annotationId)
           return (
             <div className="App">
               <Annotation className="x"
@@ -104,23 +102,46 @@ class CustomAnnotation extends Component {
                 renderContent={({ annotation }) => {
                   const { geometry } = annotation;
                   return (
-                    <div className="y"
-                      key={annotation.data.id}
-                      style={{
-                        background: 'black',
-                        color: 'white',
-                        padding: 10,
-                        position: 'absolute',
-                        fontSize: 12,
-                        left: `${geometry.x}%`,
-                        top: `${geometry.y + geometry.height}%`,
-                      }}
-                    >
-                      <div className="z">{annotation.data.title}</div>
-                      {annotation.data && annotation.data.text}
+                    <div key={annotation.data.id}>
+                      <div                      
+                        onMouseEnter={() =>
+                          context.updateAnnotationId(annotation.data.id)
+                        }
+                        onMouseLeave={() =>
+                          context.updateAnnotationId(null)
+                        }
+                        style={{
+                          position: 'absolute',
+                          left: `${geometry.x}%`,
+                          top: `${geometry.y}%`,
+                          height: `${geometry.height}%`,
+                          width: `${geometry.width}%`,
+                        }}>
+                      </div>
+                      <div
+                        onMouseEnter={() =>
+                          context.updateAnnotationId(annotation.data.id)
+                        }
+                        onMouseLeave={() =>
+                          context.updateAnnotationId(null)
+                        }                        
+                        style={{
+                          background: 'black',
+                          color: 'white',
+                          padding: 10,
+                          position: 'absolute',
+                          fontSize: 12,
+                          left: `${geometry.x}%`,
+                          top: `${geometry.y + geometry.height}%`,
+                          maxWidth: `${geometry.width}%`,
+                        }}
+                      >
+                        <div>{annotation.data.title}</div>
+                        {annotation.data && annotation.data.text}
+                      </div>
                     </div>
                   );
-                }}                
+                }}  
                 renderEditor={() => (
                   <EditorWrapper
                     onChange={this.onChange}

--- a/src/client/components/Annotation/CustomAnnotation.component.js
+++ b/src/client/components/Annotation/CustomAnnotation.component.js
@@ -87,44 +87,49 @@ class CustomAnnotation extends Component {
     return (
       <AnnotationConsumer>
         {(context) => {
-          const highlightedAnnotation = context.state.annotationId ? this.state.annotations.find(ann => ann.data.id === context.state.annotationId) : null;
+          const highlightedAnnotation = context.state.annotationId
+            ? this.state.annotations.find(
+                (ann) => ann.data.id === context.state.annotationId,
+              )
+            : null;
           return (
             <div className="App">
-              <Annotation className="x"
+              <Annotation
+                className="x"
                 src={this.props.screenshot.src}
                 alt={this.props.screenshot.alt}
                 annotations={this.state.annotations}
                 type={this.state.type}
                 value={this.state.annotation}
                 onChange={this.onChange}
-                activeAnnotations={context.state.annotationId ? [highlightedAnnotation] : []}
-                activeAnnotationComparator={(current, active) => active.data.id === current.data.id}
+                activeAnnotations={
+                  context.state.annotationId ? [highlightedAnnotation] : []
+                }
+                activeAnnotationComparator={(current, active) =>
+                  active.data.id === current.data.id
+                }
                 renderContent={({ annotation }) => {
                   const { geometry } = annotation;
                   return (
                     <div key={annotation.data.id}>
-                      <div                      
+                      <div
                         onMouseEnter={() =>
                           context.updateAnnotationId(annotation.data.id)
                         }
-                        onMouseLeave={() =>
-                          context.updateAnnotationId(null)
-                        }
+                        onMouseLeave={() => context.updateAnnotationId(null)}
                         style={{
                           position: 'absolute',
                           left: `${geometry.x}%`,
                           top: `${geometry.y}%`,
                           height: `${geometry.height}%`,
                           width: `${geometry.width}%`,
-                        }}>
-                      </div>
+                        }}
+                      />
                       <div
                         onMouseEnter={() =>
                           context.updateAnnotationId(annotation.data.id)
                         }
-                        onMouseLeave={() =>
-                          context.updateAnnotationId(null)
-                        }                        
+                        onMouseLeave={() => context.updateAnnotationId(null)}
                         style={{
                           background: 'black',
                           color: 'white',
@@ -141,7 +146,7 @@ class CustomAnnotation extends Component {
                       </div>
                     </div>
                   );
-                }}  
+                }}
                 renderEditor={() => (
                   <EditorWrapper
                     onChange={this.onChange}

--- a/src/client/container/CommentBox/BlogCard.component.jsx
+++ b/src/client/container/CommentBox/BlogCard.component.jsx
@@ -96,10 +96,11 @@ class BlogCard extends Component {
       <>
         <AnnotationConsumer>
           {( context ) => {
+            const highlightedAnnotation = context.state.annotationId;
             return (
               <div className="work-panel">
                 <div
-                  className="blog-card"
+                  className={highlightedAnnotation === this.props.annotationId ? "blog-card blog-card-hover" : "blog-card"}
                   onMouseEnter={() =>
                     context.updateAnnotationId(this.props.annotationId)
                   }

--- a/src/client/container/CommentBox/BlogCard.component.jsx
+++ b/src/client/container/CommentBox/BlogCard.component.jsx
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React, { Component, withContext } from 'react';
 import DotButton from '../../components/DotButton/DotButton.component';
 import DropDown from '../DropDown/DropDown.component';
 import Input from '../../components/Input/Input.component';
 import CommentList from '../CommentList/CommentList.component';
 import './BlogCardcss.css';
+import { AnnotationContext, AnnotationConsumer } from '../../context/AnnotationContext';
 
 // BlogCard class component
 class BlogCard extends Component {
@@ -15,6 +16,7 @@ class BlogCard extends Component {
   async componentDidMount() {
     this.getComments();
   }
+
 
   getComments = async () => {
     const fkAnnotationsId = this.props.annotationId;
@@ -71,7 +73,9 @@ class BlogCard extends Component {
     })
       .then((response) => {
         if (response.status >= 400 && response.status < 600) {
-          throw new Error('Something went wrong with response from server. Maybe you should write shorter comment.');
+          throw new Error(
+            'Something went wrong with response from server. Maybe you should write shorter comment.',
+          );
         }
         return response;
       })
@@ -90,31 +94,47 @@ class BlogCard extends Component {
     ];
     return (
       <>
-        <div className="work-panel">
-          <div className="blog-card">
-            <div className="menu-right">
-              <DotButton title="..." onClickHandle={this.onClickHandle} />
-              {this.state.showDropdown && (
-                <DropDown
-                  titleArray={titleArray}
-                  onClickHandle={this.onClickHandle}
-                />
-              )}
-            </div>
-            <Input
-              name="blogCardLabel"
-              title={this.props.title}
-              description={this.props.description}
-              placeholder="add comment..."
-              type="input"
-              handleInputChange={this.handleInputChange}
-            />
-          </div>
-          <CommentList inputValue={this.state.inputValue} />
-        </div>
+        <AnnotationConsumer>
+          {( context ) => {
+            return (
+              <div className="work-panel">
+                <div
+                  className="blog-card"
+                  onMouseEnter={() =>
+                    context.updateAnnotationId(this.props.annotationId)
+                  }
+                  onMouseLeave={() =>
+                    context.updateAnnotationId(null)
+                  }
+                >
+                  <div className="menu-right">
+                    <DotButton title="..." onClickHandle={this.onClickHandle} />
+                    {this.state.showDropdown && (
+                      <DropDown
+                        titleArray={titleArray}
+                        onClickHandle={this.onClickHandle}
+                      />
+                    )}
+                  </div>
+                  <Input
+                    name="blogCardLabel"
+                    title={this.props.title}
+                    description={this.props.description}
+                    placeholder="add comment..."
+                    type="input"
+                    handleInputChange={this.handleInputChange}
+                  />
+                </div>
+                <CommentList inputValue={this.state.inputValue} />
+              </div>
+            );
+          }}
+        </AnnotationConsumer>
       </>
     );
   }
 }
+
+BlogCard.contextType = AnnotationContext;
 
 export default BlogCard;

--- a/src/client/container/CommentBox/BlogCard.component.jsx
+++ b/src/client/container/CommentBox/BlogCard.component.jsx
@@ -1,10 +1,13 @@
-import React, { Component, withContext } from 'react';
+import React, { Component } from 'react';
 import DotButton from '../../components/DotButton/DotButton.component';
 import DropDown from '../DropDown/DropDown.component';
 import Input from '../../components/Input/Input.component';
 import CommentList from '../CommentList/CommentList.component';
 import './BlogCardcss.css';
-import { AnnotationContext, AnnotationConsumer } from '../../context/AnnotationContext';
+import {
+  AnnotationContext,
+  AnnotationConsumer,
+} from '../../context/AnnotationContext';
 
 // BlogCard class component
 class BlogCard extends Component {
@@ -16,7 +19,6 @@ class BlogCard extends Component {
   async componentDidMount() {
     this.getComments();
   }
-
 
   getComments = async () => {
     const fkAnnotationsId = this.props.annotationId;
@@ -95,18 +97,20 @@ class BlogCard extends Component {
     return (
       <>
         <AnnotationConsumer>
-          {( context ) => {
+          {(context) => {
             const highlightedAnnotation = context.state.annotationId;
             return (
               <div className="work-panel">
                 <div
-                  className={highlightedAnnotation === this.props.annotationId ? "blog-card blog-card-hover" : "blog-card"}
+                  className={
+                    highlightedAnnotation === this.props.annotationId
+                      ? 'blog-card blog-card-hover'
+                      : 'blog-card'
+                  }
                   onMouseEnter={() =>
                     context.updateAnnotationId(this.props.annotationId)
                   }
-                  onMouseLeave={() =>
-                    context.updateAnnotationId(null)
-                  }
+                  onMouseLeave={() => context.updateAnnotationId(null)}
                 >
                   <div className="menu-right">
                     <DotButton title="..." onClickHandle={this.onClickHandle} />

--- a/src/client/container/CommentBox/BlogCardcss.css
+++ b/src/client/container/CommentBox/BlogCardcss.css
@@ -16,7 +16,8 @@
     border-width: 2px;
     border-color: hsl(72, 9%, 68%);
 }
-.blog-card:hover{
+.blog-card:hover,
+.blog-card-hover{
     border-color: hsl(71, 53%, 77%);
 }
 

--- a/src/client/context/AnnotationContext.js
+++ b/src/client/context/AnnotationContext.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export const AnnotationContext = React.createContext();
+
+export class AnnotationProvider extends React.Component {
+  state = {
+    annotationId: null,
+  };
+
+  updateAnnotationId = (annotationId) => {
+    this.setState((prevState) => ({ ...prevState, annotationId }))
+  };
+
+  componentDidMount() {
+
+  }
+
+  render() {
+    // console.log('13from context', this.state.annotationId)
+    return (
+      <AnnotationContext.Provider
+        value={{
+          state: this.state,
+          updateAnnotationId: this.updateAnnotationId
+        }}
+        
+      >
+        {this.props.children}
+      </AnnotationContext.Provider>
+    );
+  }
+}
+
+export const AnnotationConsumer = AnnotationContext.Consumer;

--- a/src/client/context/AnnotationContext.js
+++ b/src/client/context/AnnotationContext.js
@@ -11,19 +11,13 @@ export class AnnotationProvider extends React.Component {
     this.setState((prevState) => ({ ...prevState, annotationId }))
   };
 
-  componentDidMount() {
-
-  }
-
   render() {
-    // console.log('13from context', this.state.annotationId)
     return (
       <AnnotationContext.Provider
         value={{
           state: this.state,
           updateAnnotationId: this.updateAnnotationId
         }}
-        
       >
         {this.props.children}
       </AnnotationContext.Provider>

--- a/src/client/pages/Projects/ProjectsPage.css
+++ b/src/client/pages/Projects/ProjectsPage.css
@@ -13,10 +13,11 @@
     z-index: 1;
     box-shadow: -2px 0px 10px 1px #AAAAAA;
     padding-bottom: 50px;
-    min-height: 100vh;
+    height: 100vh;
     position: fixed;
     top: 0;
     right: 0;
+    overflow: scroll;
 }
 
 .project-page-button{


### PR DESCRIPTION
-  After page is refreshed or after sending to another user annotations are on the screenshot, not only on the rightside panel;
- User can hover annotation on the screenshot and see the same annotation on the rightside panel;
- User can hover annotation on the rightside panel and see the same annotation on the screenshot;

- Created context for AnnotationId to interact between BlogcardListComponent and Annotation.
- Added property `overflow-wrap: break-word;` on the whole document. 
